### PR TITLE
feat: add `capture_stdout` arg

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: exec_from
-version: 1.2.1
+version: 1.3.0
 crystal: ">= 0.35"
 license: MIT
 

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -5,6 +5,7 @@ module ExecFrom
     arguments : Enumerable(String) = [] of String,
     environment : Process::Env = nil,
     clear_environment : Bool = false,
+    capture_stderr : Bool = true,
     input : IO | Process::Redirect = Process::Redirect::Close
   ) : NamedTuple(output: IO, exit_code: Int32)
     output = IO::Memory.new
@@ -15,7 +16,7 @@ module ExecFrom
       env: environment,
       clear_env: clear_environment,
       output: output,
-      error: output,
+      error: capture_stderr ? output : Process::Redirect::Close,
     )
 
     {


### PR DESCRIPTION
Adds `capture_stdout` argument to `ExecFrom.exec_from`. 
Defaults to `true` which interleaves stderr with the process's output. If `false`, stderr is closed.