### PR TITLE
refactor: remove NamedTuples in favor of struct

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: exec_from
-version: 1.3.0
+version: 2.0.0
 crystal: ">= 0.35"
 license: MIT
 

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -1,4 +1,12 @@
 module ExecFrom
+  struct Result
+    getter status : Process::Status
+    getter output : IO
+
+    def initialize(@status, @output)
+    end
+  end
+
   def self.exec_from(
     directory : String,
     command : String,
@@ -7,9 +15,9 @@ module ExecFrom
     clear_environment : Bool = false,
     capture_stderr : Bool = true,
     input : IO | Process::Redirect = Process::Redirect::Close
-  ) : NamedTuple(output: IO, exit_code: Int32)
+  ) : Result
     output = IO::Memory.new
-    result = Process.run(
+    status = Process.run(
       command: "./bin/exec_from",
       args: [directory, command].concat(arguments),
       input: Process::Redirect::Close,
@@ -19,9 +27,6 @@ module ExecFrom
       error: capture_stderr ? output : Process::Redirect::Close,
     )
 
-    {
-      output:    output,
-      exit_code: result.exit_code,
-    }
+    Result.new(status, output)
   end
 end

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -1,11 +1,5 @@
 module ExecFrom
-  struct Result
-    getter status : Process::Status
-    getter output : IO
-
-    def initialize(@status, @output)
-    end
-  end
+  record Result, status : Process::Status, output : IO
 
   def self.exec_from(
     directory : String,

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -1,9 +1,5 @@
-require "json"
-
 module ExecFrom
   struct Result
-    include JSON::Serializable
-
     getter status : Process::Status
     getter output : IO
 

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -1,5 +1,9 @@
+require "json"
+
 module ExecFrom
   struct Result
+    include JSON::Serializable
+
     getter status : Process::Status
     getter output : IO
 

--- a/src/exec_from.cr
+++ b/src/exec_from.cr
@@ -18,9 +18,9 @@ module ExecFrom
     environment : Process::Env = nil,
     clear_environment : Bool = false,
     capture_stderr : Bool = true,
-    input : IO | Process::Redirect = Process::Redirect::Close
+    input : IO | Process::Redirect = Process::Redirect::Close,
+    output : IO = IO::Memory.new
   ) : Result
-    output = IO::Memory.new
     status = Process.run(
       command: "./bin/exec_from",
       args: [directory, command].concat(arguments),


### PR DESCRIPTION
`ExecFrom.exec_from` now returns [`ExecFrom::Result`](https://github.com/place-labs/exec_from/blob/ed41f93b68728594c39774f43619dbd9efc5367b/src/exec_from.cr#L2-L8)